### PR TITLE
Event page - fixed styling

### DIFF
--- a/pages/Events/[pid].tsx
+++ b/pages/Events/[pid].tsx
@@ -74,7 +74,7 @@ const EventDetail: FC = () => {
   return (
     <div className="event-detail px-5 md:px-28 lg:px-64 py-10">
       <MaterialCard className="w-full h-full rounded-t-md relative">
-        <div className="overview-card md:h-96 flex flex-col md:flex-row">
+        <div className="overview-card flex flex-col md:flex-row">
           <Tag categories={parsedCurrEvent.categories} />
           <div className="w-full h-1/3 md:w-2/3 md:h-full image-container relative">
             <Image src={parsedCurrEvent.coverImageUrl} layout="fill" priority />
@@ -109,7 +109,7 @@ const EventDetail: FC = () => {
         </div>
       </MaterialCard>
       <MaterialCard className="mt-5 w-full h-full p-5 rounded-b-md">
-        <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} className="prose">
+        <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} className="prose max-w-full">
           {parsedCurrEvent.content}
         </Markdown>
       </MaterialCard>

--- a/scss/components/_EventDetail.scss
+++ b/scss/components/_EventDetail.scss
@@ -28,6 +28,8 @@
     }
 
     @media (min-width: 768px) {
+      height: 450px;
+
       .tag {
         position: absolute;
         padding: 10px 15px;


### PR DESCRIPTION
### Ticket
[Ticket Link](https://trello.com/c/MbUZLpd2/45-event-page-fix-title-and-content-styling)

### What is changed / added
- fixed title overlapping with the register button
- fixed event content margin-right issue

### Screenshots
before
<img width="1010" alt="Screen Shot 2022-02-13 at 1 26 40 PM" src="https://user-images.githubusercontent.com/36747253/153769742-b2da6772-f741-46ed-a710-6ab2bef3ade6.png">


after 
<img width="1015" alt="Screen Shot 2022-02-13 at 1 43 00 PM" src="https://user-images.githubusercontent.com/36747253/153769731-98bb6505-1437-4d03-aa23-b75bfc71c01f.png">

