### PR TITLE
Fixed filter deselection

### DIFF
--- a/pages/Blogs/index.tsx
+++ b/pages/Blogs/index.tsx
@@ -34,7 +34,7 @@ const Blogs: FC = () => {
            * Case 2: Something other than 'All' is selected, then we should de-select 'All'
            * Case 3: If 'All' is selected, then we should de-select everything other than 'All'
            */
-           if (_.isEmpty(newSelectedCategories)) {
+          if (_.isEmpty(newSelectedCategories)) {
             newSelectedCategories = ['All'];
           } else if (
             newSelectedCategories.length > 1 &&

--- a/pages/Blogs/index.tsx
+++ b/pages/Blogs/index.tsx
@@ -32,8 +32,9 @@ const Blogs: FC = () => {
           /**
            * Case 1: Nothing is selected, then we should select 'All'
            * Case 2: Something other than 'All' is selected, then we should de-select 'All'
+           * Case 3: If 'All' is selected, then we should de-select everything other than 'All'
            */
-          if (_.isEmpty(newSelectedCategories)) {
+           if (_.isEmpty(newSelectedCategories)) {
             newSelectedCategories = ['All'];
           } else if (
             newSelectedCategories.length > 1 &&
@@ -41,6 +42,8 @@ const Blogs: FC = () => {
             newSelectedCategories.includes('All')
           ) {
             newSelectedCategories = removeElement(newSelectedCategories, 'All');
+          } else if (currOptionName === 'All') {
+            newSelectedCategories = ['All'];
           }
 
           setSelectedCategories(newSelectedCategories);

--- a/pages/Events/index.tsx
+++ b/pages/Events/index.tsx
@@ -32,6 +32,7 @@ const Events: FC = () => {
           /**
            * Case 1: Nothing is selected, then we should select 'All'
            * Case 2: Something other than 'All' is selected, then we should de-select 'All'
+           * Case 3: If 'All' is selected, then we should de-select everything other than 'All'
            */
           if (_.isEmpty(newSelectedCategories)) {
             newSelectedCategories = ['All'];
@@ -41,6 +42,8 @@ const Events: FC = () => {
             newSelectedCategories.includes('All')
           ) {
             newSelectedCategories = removeElement(newSelectedCategories, 'All');
+          } else if (currOptionName === 'All') {
+            newSelectedCategories = ['All'];
           }
 
           setSelectedCategories(newSelectedCategories);

--- a/pages/Partners/index.tsx
+++ b/pages/Partners/index.tsx
@@ -32,6 +32,7 @@ const Partners: FC = () => {
           /**
            * Case 1: Nothing is selected, then we should select 'All'
            * Case 2: Something other than 'All' is selected, then we should de-select 'All'
+           * Case 3: If 'All' is selected, then we should de-select everything other than 'All'
            */
           if (_.isEmpty(newSelectedCategories)) {
             newSelectedCategories = ['All'];
@@ -41,6 +42,8 @@ const Partners: FC = () => {
             newSelectedCategories.includes('All')
           ) {
             newSelectedCategories = removeElement(newSelectedCategories, 'All');
+          } else if (currOptionName === 'All') {
+            newSelectedCategories = ['All'];
           }
 
           setSelectedCategories(newSelectedCategories);


### PR DESCRIPTION
### Ticket
None

### What is changed / added
Previously we started from selecting 'All' in filters. if we select another category other than 'All' before deselecting 'All', it would allow both categories to be selected. This PR forces to select only 'All' if user selects multiple categories and one of them is 'All'. 

### Screenshots
Previous issue:
![スクリーンショット 2022-03-09 10 29 54](https://user-images.githubusercontent.com/64772347/157474335-5bdc440a-1fdd-452a-be03-05fb4de08bf2.png)

