### PR TITLE
Fixed typo on team section for 'Associate'

### DIFF
--- a/components/Home/TeamMemberSection.tsx
+++ b/components/Home/TeamMemberSection.tsx
@@ -12,7 +12,7 @@ const TeamMemberSection: FC = () => {
   const { members } = useAppSelector((state) => state.members);
 
   return (
-    <SectionWrapper subtitle="EXECUTIVES & ASSOICATES" title="OUR TEAM">
+    <SectionWrapper subtitle="EXECUTIVES & ASSOCIATES" title="OUR TEAM">
       {_.isEmpty(members) ? (
         <HorizontalSkeletonLoader numSkeletons={1} count={8} className="w-1/2" />
       ) : (


### PR DESCRIPTION
### Ticket
[[Ticket Link](https://trello.com/c/pyTTc4Bf/57-fix-typo-on-team-section-for-associate)]

### What is changed / added
Fixed typo on team section for 'Associate'. (was 'Assoicates', changed to 'Associates')

### Screenshots
![image](https://user-images.githubusercontent.com/89106881/191640596-72938f2c-1022-439b-9880-f26437d6e098.png)

